### PR TITLE
Kick the tires on the Parceler library. Sad Panda - all member variables have to be public in our models to avoid using reflection

### DIFF
--- a/app/src/main/java/com/smacgregor/newyorktimessearch/core/Article.java
+++ b/app/src/main/java/com/smacgregor/newyorktimessearch/core/Article.java
@@ -2,6 +2,8 @@ package com.smacgregor.newyorktimessearch.core;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.parceler.Parcel;
+
 import java.net.URISyntaxException;
 import java.util.List;
 
@@ -10,17 +12,17 @@ import cz.msebera.android.httpclient.client.utils.URIBuilder;
 /**
  * Created by smacgregor on 2/9/16.
  */
+@Parcel
 public class Article {
 
-    private Headline headline;
-
-    private String webUrl;
+    Headline headline;
+    String webUrl;
 
     @SerializedName("multimedia")
-    private List<Thumbnail> thumbnails;
+    List<Thumbnail> thumbnails;
 
     @SerializedName("abstract")
-    private String shortSummary;
+    String shortSummary;
 
     public String getWebUrl() {
         // The NY Times API returns non mobile article urls.
@@ -41,9 +43,10 @@ public class Article {
         return (thumbnails != null && thumbnails.size() > 0) ? thumbnails.get(0) : null;
     }
 
-    private class Headline {
+    @Parcel
+    public static class Headline {
 
-        private String main;
+        String main;
 
         public String getMain() {
             return main;

--- a/app/src/main/java/com/smacgregor/newyorktimessearch/core/Thumbnail.java
+++ b/app/src/main/java/com/smacgregor/newyorktimessearch/core/Thumbnail.java
@@ -2,15 +2,18 @@ package com.smacgregor.newyorktimessearch.core;
 
 import android.text.TextUtils;
 
+import org.parceler.Parcel;
+
 /**
  * Created by smacgregor on 2/9/16.
  */
+@Parcel
 public class Thumbnail {
 
-    private String url;
-    private String type;
-    private int width;
-    private int height;
+    String url;
+    String type;
+    int width;
+    int height;
 
     public String getUrl() {
         // TODO - find a better way to construct the thumbnail url

--- a/app/src/main/java/com/smacgregor/newyorktimessearch/viewing/ArticleActivity.java
+++ b/app/src/main/java/com/smacgregor/newyorktimessearch/viewing/ArticleActivity.java
@@ -13,12 +13,14 @@ import android.webkit.WebViewClient;
 import com.smacgregor.newyorktimessearch.R;
 import com.smacgregor.newyorktimessearch.core.Article;
 
+import org.parceler.Parcels;
+
 import butterknife.Bind;
 import butterknife.ButterKnife;
 
 public class ArticleActivity extends AppCompatActivity {
 
-    private static final String EXTRA_ARTICLE_URL = "com.smacgregor.newyorktimessearch.viewing.article_url";
+    private static final String EXTRA_ARTICLE = "com.smacgregor.newyorktimessearch.viewing.article";
 
     @Bind(R.id.web_full_article) WebView mWebView;
 
@@ -32,12 +34,13 @@ public class ArticleActivity extends AppCompatActivity {
         setSupportActionBar(toolbar);
 
         setupWebView();
-        loadWebView(getIntent().getStringExtra(ArticleActivity.EXTRA_ARTICLE_URL));
+        Article article = (Article) Parcels.unwrap(getIntent().getParcelableExtra(ArticleActivity.EXTRA_ARTICLE));
+        loadWebView(article.getWebUrl());
     }
 
     public static Intent getStartIntent(Context context, Article article) {
         Intent startIntent = new Intent(context, ArticleActivity.class);
-        startIntent.putExtra(ArticleActivity.EXTRA_ARTICLE_URL, article.getWebUrl());
+        startIntent.putExtra(ArticleActivity.EXTRA_ARTICLE, Parcels.wrap(article));
         return startIntent;
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,8 @@ buildscript {
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+
+        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     }
 }
 


### PR DESCRIPTION
_sad panda_
